### PR TITLE
Update OAuth SDK to AFNetworking 2

### DIFF
--- a/OAuthSDK/YMHTTPClient.h
+++ b/OAuthSDK/YMHTTPClient.h
@@ -5,13 +5,13 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "AFHTTPClient.h"
+#import "AFNetworking.h"
 
 static NSString *const STATE_PARAM = @"state";
 
 /**
  Represents an object that contains a queue of HTTP operations.
- At the moment, this is essentially a lightweight wrapper around AFHTTPClient.
+ At the moment, this is essentially a lightweight wrapper around AFHTTPRequestOperationManager.
  */
 @interface YMHTTPClient : NSObject
 @property (nonatomic, strong) NSString *authToken;

--- a/OAuthSDK/YMLoginController.m
+++ b/OAuthSDK/YMLoginController.m
@@ -48,13 +48,21 @@ NSString * const YAMMER_KEYCHAIN_STATE_KEY = @"yammerState";
     NSDictionary *params = @{@"client_id": YAMMER_APP_CLIENT_ID,
                              @"redirect_uri": YAMMER_AUTH_REDIRECT_URI,
                              @"state": stateParam};
-    
-    NSString *query = AFQueryStringFromParametersWithEncoding(params, NSUTF8StringEncoding);
-    NSString *urlString = [NSString stringWithFormat:@"%@/dialog/oauth?%@", YAMMER_BASE_URL, query];
+
+    NSString *baseUrlString = [NSString stringWithFormat:@"%@/dialog/oauth", YAMMER_BASE_URL];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:baseUrlString]];
+
+    AFHTTPRequestSerializer * requestSerializer = [[AFHTTPRequestSerializer alloc] init];
+    NSError *error;
+    NSURLRequest *serializedRequest = [requestSerializer requestBySerializingRequest:request withParameters:params error:&error];
+
+    if (error) {
+        NSLog(@"Failed to serialize request: %@", error);
+    }
 
     // Yammer SDK: This will launch mobile (iOS) Safari and begin the two-step login process.
     // The app delegate will intercept the callback from the login page.  See app delegate for method call.
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlString]];
+    [[UIApplication sharedApplication] openURL:serializedRequest.URL];
 }
 
 - (NSString *)uniqueIdentifier

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '5.0'
+platform :ios, '6.0'
 
-pod 'AFNetworking'
+pod 'AFNetworking', '~> 2.0'
 pod 'PDKeychainBindingsController'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,33 @@
 PODS:
-  - AFNetworking (1.3.1)
+  - AFNetworking (2.5.0):
+    - AFNetworking/NSURLConnection (= 2.5.0)
+    - AFNetworking/NSURLSession (= 2.5.0)
+    - AFNetworking/Reachability (= 2.5.0)
+    - AFNetworking/Security (= 2.5.0)
+    - AFNetworking/Serialization (= 2.5.0)
+    - AFNetworking/UIKit (= 2.5.0)
+  - AFNetworking/NSURLConnection (2.5.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.5.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.5.0)
+  - AFNetworking/Security (2.5.0)
+  - AFNetworking/Serialization (2.5.0)
+  - AFNetworking/UIKit (2.5.0):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
   - PDKeychainBindingsController (0.0.1)
 
 DEPENDENCIES:
-  - AFNetworking
+  - AFNetworking (~> 2.0)
   - PDKeychainBindingsController
 
 SPEC CHECKSUMS:
-  AFNetworking: 9ec8aafb9269236a7630bd8d9838ce2ba30fa2a0
-  PDKeychainBindingsController: 463c207f8726e4aaec1ec20fd1876082ee86cb0a
+  AFNetworking: 0f54cb5d16ce38c1b76948faffb8d5fb705021c7
+  PDKeychainBindingsController: 529f006d0707646b2bf0c79d476acdda58a9a587
 
-COCOAPODS: 0.22.2
+COCOAPODS: 0.35.0

--- a/ios-oauth-demo.xcodeproj/project.pbxproj
+++ b/ios-oauth-demo.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0A4536C17373482D98C767A3 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
+		04F07AE353B7491B6EE66771 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		4F0D177F1788025E00DFB39D /* YMAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YMAppDelegate.h; sourceTree = "<group>"; };
 		4F0D17801788025E00DFB39D /* YMAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YMAppDelegate.m; sourceTree = "<group>"; };
 		4F0D17811788025E00DFB39D /* YMSampleHomeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YMSampleHomeViewController.h; sourceTree = "<group>"; };
@@ -53,6 +53,7 @@
 		4FFBD4D01777C17C00C2B71D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = "en.lproj/HomeView~iphone.xib"; sourceTree = "<group>"; };
 		4FFBD4D31777C17C00C2B71D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = "en.lproj/HomeView~ipad.xib"; sourceTree = "<group>"; };
 		4FFBD4DC1777C58C00C2B71D /* blue-button-bg.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "blue-button-bg.png"; sourceTree = "<group>"; };
+		6D7A16839373520DD3611D98 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		9CCFB057A4A0796814C65E02 /* YMConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YMConstants.h; sourceTree = "<group>"; };
 		9CCFB342B66EA056FD84325B /* YMLoginController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YMLoginController.h; sourceTree = "<group>"; };
 		9CCFB69376D1B5E258760FAB /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -82,6 +83,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1122FD5B408CE698C57AEA25 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6D7A16839373520DD3611D98 /* Pods.debug.xcconfig */,
+				04F07AE353B7491B6EE66771 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		4FFBD4A81777C17C00C2B71D = {
 			isa = PBXGroup;
 			children = (
@@ -91,7 +101,7 @@
 				4FFBD4B31777C17C00C2B71D /* Frameworks */,
 				4FFBD4B21777C17C00C2B71D /* Products */,
 				9CCFBA70BCABA8904C1D0CD2 /* README.md */,
-				0A4536C17373482D98C767A3 /* Pods.xcconfig */,
+				1122FD5B408CE698C57AEA25 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -275,7 +285,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -385,7 +395,7 @@
 		};
 		4FFBD4D81777C17C00C2B71D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0A4536C17373482D98C767A3 /* Pods.xcconfig */;
+			baseConfigurationReference = 6D7A16839373520DD3611D98 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApp/ios-oauth-demo-Prefix.pch";
@@ -397,7 +407,7 @@
 		};
 		4FFBD4D91777C17C00C2B71D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0A4536C17373482D98C767A3 /* Pods.xcconfig */;
+			baseConfigurationReference = 04F07AE353B7491B6EE66771 /* Pods.release.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApp/ios-oauth-demo-Prefix.pch";


### PR DESCRIPTION

The OAuth SDK requires AFNetworking 1.3, which is a problem for me because my existing project uses AFNetworking 2.5. [I'm not the only one with this issue](http://stackoverflow.com/questions/23760403/yammer-does-not-use-the-latest-version-of-afnetworking).

I've updated the OAuth SDK to AFNetworking 2.5 with minimal, non-breaking changes. 

Other things it might be a good idea to update:

- Change `getPath:parameters:success:failure:` and `postPath:parameters:success:failure:` methods in YMHTTPClient.h to match AFNetworking 2 methods (`GET:parameters:success:failure:` & `POST:parameters:success:failure:`).
- Rename the `YMHTTPClient` class and its `httpClient` property. This class is a wrapper for `AFHTTPClient` which does not exist in AFNetworking 2.

Thoughts?
